### PR TITLE
maintain LayoutGoogle and ArticleEdit

### DIFF
--- a/front/nuxt_app/components/ArticleEdit.vue
+++ b/front/nuxt_app/components/ArticleEdit.vue
@@ -16,7 +16,8 @@
       <div v-if="evaluation == '1'" class="m-4">😞</div>
       <div v-else class="opacity-50 m-4" @click="evalPlace(1)">😞</div>
     </div>
-    <layout-google-map />
+    <div>{{ mapPosition.lat }}{{ mapPosition.lng }}</div>
+    <layout-google-map @latLng='clickPosition'  />
     <div id="editorjs" class="mx-8 mt-4 tracking-wider"></div>
     <div class="text-center">
       <base-button :title="buttonTitle1" :link="buttonLink1" @buttonEvent="save(true)" />
@@ -140,8 +141,8 @@ export default defineComponent({
             mainImage: "",
             uid      : uid,
             like     : 0,
-            lat      : "",
-            lng      : "",
+            lat      : mapPosition.lat,
+            lng      : mapPosition.lng,
             author   : data.author,
             icon     : "",
             evaluation : evaluation.value,
@@ -195,6 +196,14 @@ export default defineComponent({
       evaluation.value = String(num)
     }
 
+    //LayoutGoogleMap.vueからデータを受け取る
+    const mapPosition:any = ref({})
+
+    const clickPosition = (position:any) =>{
+      console.log(position.lng)
+      mapPosition.value = { lat:position.lat, lng:position.lng }
+    }
+
     onMounted(async () => {
       id.value = route.value.params.id
       const myArticle = await getFireArticle(id.value)
@@ -217,6 +226,8 @@ export default defineComponent({
       save,
       getImageFile,
       saveStorage,
+      clickPosition,
+      mapPosition,
       id, 
       route, 
       evalPlace,

--- a/front/nuxt_app/pages/map 2.vue
+++ b/front/nuxt_app/pages/map 2.vue
@@ -29,7 +29,7 @@ const GOOGLE_MAPS_API_KEY = 'AIzaSyBbpYgXLDr3PWNAoWXhmTzdCTh7f8TlKsc'
 import { auth } from "../plugins/firebase";
 
 export default defineComponent({
-    setup(props, { emit }) {
+    setup() {
         const { coords } = useGeolocation()
         const currPos = computed(()=>({
                 lat: coords.value.latitude,
@@ -37,9 +37,6 @@ export default defineComponent({
         }))
 
         const otherPos = ref(null)
-        const sendPositionToParent = () => {
-          emit("latLng", otherPos.value);
-        }
 
         const loader = new Loader({ apiKey: GOOGLE_MAPS_API_KEY })
         const mapDiv = ref(null)
@@ -48,16 +45,15 @@ export default defineComponent({
         onMounted(async () => {
             await loader.load()
             map.value = new google.maps.Map(mapDiv.value, {
+                //遅れて入ってくる
                 center:currPos.value,
                 // center: {lat:35.68, lng:139.69 },
                 zoom:7
             })
             clickListener = map.value.addListener(
                 'click',
-                ({ latLng: { lat, lng} })=>{
-                  (otherPos.value = {lat: lat(), lng: lng()})
-                  sendPositionToParent()
-                }
+                ({ latLng: { lat, lng} })=>
+                    (otherPos.value = {lat: lat(), lng: lng()})
             )
         })
         onUnmounted(async() => {

--- a/front/nuxt_app/plugins/useGeolocation 2.js
+++ b/front/nuxt_app/plugins/useGeolocation 2.js
@@ -1,0 +1,22 @@
+
+import { onUnmounted, ref, onMounted } from '@nuxtjs/composition-api'
+
+export function useGeolocation(){
+
+    const coords = ref({ latitude:35.735682062563185, longitude:139.6516558688486 })
+    const isSupported = 'navigator' in window && 'geolocation' in navigator
+    
+    let watcher = null
+    onMounted(()=>{
+        if(isSupported)
+            watcher = navigator.geolocation.watchPosition(
+                position => (coords.value = position.coords)
+            )
+    })
+
+    onUnmounted(()=>{
+        if(watcher) navigator.geolocation.clearWatch(watcher)
+    })
+
+    return{ coords, isSupported }
+}


### PR DESCRIPTION
GoogleMapでクリックした場所の緯度経度を、Firebaseで送信できるように対応しました。
・子コンポーネント（LayoutGoogleMap）から親（ArticleEdit.vue）への受け渡し
・Firebaseの送信項目の追加